### PR TITLE
Fix asset base for GitHub Pages

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -4,7 +4,9 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
-  base: '/',
+  // Use relative asset paths so the site loads correctly on GitHub Pages
+  // regardless of the final publish base URL.
+  base: './',
   build: {
     outDir: 'dist',
     assetsDir: 'assets',


### PR DESCRIPTION
## Summary
- switch Vite base path to relative URLs so assets load correctly on GitHub Pages deployments

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692faf5c6634832fb80a70601e121357)